### PR TITLE
Use unmountComponentAtNode from ReactDOM and not React.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -18,14 +18,14 @@
 
   :plugins [[lein-cljsbuild "1.0.5"]
             [lein-doo "0.1.3-SNAPSHOT"]]
-  
+
   :aliases {"test" ["with-profile" "test" "doo" "slimer" "test"]}
 
   :source-paths ["src"]
-  
+
   :profiles {:test {:dependencies [[org.omcljs/om "0.9.0" :exclusions [cljsjs/react]]]}}
-                 
-  :cljsbuild {:builds 
+
+  :cljsbuild {:builds
               {:test {:source-paths ["src" "test"]
                       :compiler {:output-to "target/testable.js"
                                  :main 'test.test-runner

--- a/src/cljs_react_test/utils.cljs
+++ b/src/cljs_react_test/utils.cljs
@@ -3,12 +3,12 @@
   (:require [cljsjs.react]
             [dommy.core :as dommy :refer-macros [sel sel1]]))
 
-;; For Fixtures 
+;; For Fixtures
 
 (defn unmount!
   "Unmounts the React Component at a node"
   [n]
-  (.unmountComponentAtNode js/React n))
+  (.unmountComponentAtNode js/ReactDOM n))
 
 (defn container-div []
   (let [id (str "container-" (gensym))


### PR DESCRIPTION
This change uses `ReactDOM. unmountComponentAtNode` instead of `React. unmountComponentAtNode` - with the latter being deprecated in 0.14 and completely removed in 0.15.
It also removes some white spaces.
